### PR TITLE
feat(auth): use PasswordInput component in auth forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+
+# JetBrain IDEs
+.idea

--- a/apps/web/app/auth/ui/components/login_form.tsx
+++ b/apps/web/app/auth/ui/components/login_form.tsx
@@ -17,6 +17,7 @@ import { FieldErrorBag } from '@workspace/ui/components/field-error-bag'
 
 import useFlashMessage from '#common/ui/hooks/use_flash_message'
 import { useTranslation } from '#common/ui/hooks/use_translation'
+import { PasswordInput } from '@workspace/ui/components/password-input'
 
 export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRef<'form'>) {
   const { data, setData, errors, post } = useForm({
@@ -77,9 +78,8 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
                 {t('auth.signin.actions.forgot_password')}
               </Link>
             </div>
-            <Input
+            <PasswordInput
               id="password"
-              type="password"
               value={data.password}
               onChange={(e) => setData('password', e.target.value)}
               placeholder={t('auth.signin.form.password.placeholder')}

--- a/apps/web/app/auth/ui/components/registration_form.tsx
+++ b/apps/web/app/auth/ui/components/registration_form.tsx
@@ -10,6 +10,7 @@ import { FieldErrorBag } from '@workspace/ui/components/field-error-bag'
 
 import { useTranslation } from '#common/ui/hooks/use_translation'
 import useFlashMessage from '#common/ui/hooks/use_flash_message'
+import { PasswordInput } from '@workspace/ui/components/password-input'
 
 export function RegistrationForm({ className, ...props }: React.ComponentPropsWithoutRef<'form'>) {
   const { data, setData, errors, post } = useForm({
@@ -81,9 +82,8 @@ export function RegistrationForm({ className, ...props }: React.ComponentPropsWi
 
           <Field>
             <FieldLabel htmlFor="password">{t('auth.registration.form.password.label')}</FieldLabel>
-            <Input
+            <PasswordInput
               id="password"
-              type="password"
               value={data.password}
               onChange={(e) => setData('password', e.target.value)}
               placeholder={t('auth.registration.form.password.placeholder')}
@@ -97,9 +97,8 @@ export function RegistrationForm({ className, ...props }: React.ComponentPropsWi
             <FieldLabel htmlFor="passwordConfirmation">
               {t('auth.registration.form.password_confirmation.label')}
             </FieldLabel>
-            <Input
+            <PasswordInput
               id="passwordConfirmation"
-              type="password"
               value={data.passwordConfirmation}
               onChange={(e) => setData('passwordConfirmation', e.target.value)}
               placeholder={t('auth.registration.form.password_confirmation.placeholder')}


### PR DESCRIPTION
- Refactor LoginForm and RegistrationForm to use PasswordInput instead of generic Input for password fields.
- Update .gitignore to exclude .idea directory for JetBrains IDEs.